### PR TITLE
Handle get status failure as a job failure

### DIFF
--- a/Edge10.Birst.Tests/TestBirstAdminService.cs
+++ b/Edge10.Birst.Tests/TestBirstAdminService.cs
@@ -5,6 +5,8 @@ using Edge10.Birst.BirstWebService;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Web.Services.Protocols;
+using System.Xml;
 using Edge10.Birst.Utils;
 
 namespace Edge10.Birst.Tests
@@ -179,6 +181,20 @@ namespace Edge10.Birst.Tests
 
 			var result = this.TestSubject.GetJobStatus("job token");
 			Assert.AreEqual(serviceStatus, result);
+		}
+		
+		[Test]
+		public void GetJobStatus_Returns_Failed_On_Soap_Exception()
+		{
+			var authToken = SetupLogin();
+
+			_birstServiceWrapper.Setup(b => b.GetJobStatus(authToken, "job token"))
+				.Throws(new SoapException("Oops", XmlQualifiedName.Empty));
+
+			var result = TestSubject.GetJobStatus("job token");
+			
+			Assert.AreEqual("Failed", result.statusCode);
+			Assert.AreEqual("Oops", result.message);
 		}
 
 		[Test]

--- a/Edge10.Birst/BirstAdminService.cs
+++ b/Edge10.Birst/BirstAdminService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Web.Services.Protocols;
 using Edge10.Birst.BirstWebService;
 using Edge10.Birst.Utils;
 
@@ -120,7 +121,19 @@ namespace Edge10.Birst
 		public StatusResult GetJobStatus(string jobToken)
 		{
 			var authToken = Login();
-			return _birstServiceWrapper.GetJobStatus(authToken, jobToken);
+			try
+			{
+				return _birstServiceWrapper.GetJobStatus(authToken, jobToken);
+			}
+			catch (SoapException e)
+			{
+				return new StatusResult
+				{
+					statusCode = "Failed",
+					message = e.Message
+				};
+			}
+
 		}
 
 		/// <summary>


### PR DESCRIPTION
Under some circumstances getJobStatus request fails when a job failed because of wrong params or so.