### PR TITLE
E10-334: Service wrapper from URL

### DIFF
--- a/Edge10.Birst.Tests/TestBirstServiceWrapper.cs
+++ b/Edge10.Birst.Tests/TestBirstServiceWrapper.cs
@@ -27,20 +27,8 @@ namespace Edge10.Birst.Tests
 		[Test]
 		public void Constructor_Throws_Exception_On_Null_Parameters()
 		{
-			Assert.Throws<ArgumentNullException>(() => new BirstServiceWrapper(null));
-		}
-
-		[Test]
-		public void EnsureConfigured_Is_Called_Then_Url_And_CookieContainer_Are_Set_On_Service()
-		{
-			_configuration.Setup(c => c.Uri).Returns(new Uri("http://birst"));
-
-			//testing this using a private object reading the internal service field as nothing
-			//public can run this without making a call to the live service
-			var service = new MsTest.PrivateObject(new BirstServiceWrapper(_configuration.Object)).GetField("_service") as CommandWebService;
-
-			Assert.AreEqual("http://birst/CommandWebservice.asmx", service.Url.ToString());
-			Assert.IsNotNull(service.CookieContainer);
+			Assert.That(() => new BirstServiceWrapper((IBirstConfiguration)null), Throws.ArgumentNullException);
+			Assert.That(() => new BirstServiceWrapper((Uri)null), Throws.ArgumentNullException);
 		}
 
 		[Test]
@@ -48,7 +36,31 @@ namespace Edge10.Birst.Tests
 		{
 			_configuration.Setup(c => c.Uri).Returns<Uri>(null);
 
-			Assert.Throws<BirstException>(() => new BirstServiceWrapper(_configuration.Object));
+			Assert.That(() => new BirstServiceWrapper(_configuration.Object), Throws.InstanceOf<BirstException>());
+		}
+
+		[Test]
+		public void Url_And_CookieContainer_Are_Set_On_Service_From_Configuration()
+		{
+			_configuration.Setup(c => c.Uri).Returns(new Uri("http://birst"));
+
+			//testing this using a private object reading the internal service field as nothing
+			//public can run this without making a call to the live service
+			var service = new MsTest.PrivateObject(new BirstServiceWrapper(_configuration.Object)).GetField("_service") as CommandWebService;
+
+			Assert.That(service.Url, Is.EqualTo("http://birst/CommandWebservice.asmx"));
+			Assert.That(service.CookieContainer, Is.Not.Null);
+		}
+
+		[Test]
+		public void Url_And_CookieContainer_Are_Set_On_Service_From_Uri()
+		{
+			//testing this using a private object reading the internal service field as nothing
+			//public can run this without making a call to the live service
+			var service = new MsTest.PrivateObject(new BirstServiceWrapper(new Uri("http://birst"))).GetField("_service") as CommandWebService;
+
+			Assert.That(service.Url, Is.EqualTo("http://birst/CommandWebservice.asmx"));
+			Assert.That(service.CookieContainer, Is.Not.Null);
 		}
 	}
 }

--- a/Edge10.Birst/BirstServiceWrapper.cs
+++ b/Edge10.Birst/BirstServiceWrapper.cs
@@ -22,13 +22,30 @@ namespace Edge10.Birst
 		public BirstServiceWrapper(IBirstConfiguration configuration)
 		{
 			if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-			
+
 			if (configuration.Uri == null)
 				throw new BirstException("Birst has not been configured for this environment");
-			
+
+			CreateService(configuration.Uri);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="BirstServiceWrapper"/> class.
+		/// </summary>
+		/// <param name="uri">The URI.</param>
+		/// <exception cref="ArgumentNullException">uri</exception>
+		public BirstServiceWrapper(Uri uri)
+		{
+			if (uri == null) throw new ArgumentNullException(nameof(uri));
+
+			CreateService(uri);
+		}
+
+		private void CreateService(Uri uri)
+		{
 			_service = new CommandWebService
 			{
-				Url             = new Uri(configuration.Uri, "CommandWebservice.asmx").ToString(),
+				Url             = new Uri(uri, "CommandWebservice.asmx").ToString(),
 				CookieContainer = new CookieContainer()
 			};
 		}


### PR DESCRIPTION
Add another constructor to create instances of the service wrapper using a URL rather than the whole config object.