### PR TITLE
E10-361: Uri as parameter

### DIFF
--- a/Edge10.Birst.Tests/TestBirstAdminService.cs
+++ b/Edge10.Birst.Tests/TestBirstAdminService.cs
@@ -226,12 +226,10 @@ namespace Edge10.Birst.Tests
 		[Test]
 		public async Task GetSSOToken_Returns_Token_With_Parameters()
 		{
-			_birstConfiguration.Setup(c => c.Uri).Returns(new Uri("http://birst"));
-
 			_httpClient.Setup(h => h.PostAsync(new Uri("http://birst/tokengenerator.aspx"), It.Is<FormUrlEncodedContent>(c => c.ReadAsStringAsync().Result == "birst.spaceId=Space_ID_1&birst.ssopassword=SSO_Password_1&birst.username=email%40somewhere.com_1")))
 				.ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("token_response") });
 
-			var token = await TestSubject.GetSSOToken("Space_ID_1", "SSO_Password_1", "email@somewhere.com_1");
+			var token = await TestSubject.GetSSOToken(new Uri("http://birst"), "Space_ID_1", "SSO_Password_1", "email@somewhere.com_1");
 
 			Assert.AreEqual("token_response", token);
 		}
@@ -239,9 +237,10 @@ namespace Edge10.Birst.Tests
 		[Test]
 		public void GetSSOToken_Throws_On_Null_Parameters()
 		{
-			Assert.ThrowsAsync<ArgumentNullException>(() => TestSubject.GetSSOToken(null, "sso-password", "username"));
-			Assert.ThrowsAsync<ArgumentNullException>(() => TestSubject.GetSSOToken("space-id", null, "username"));
-			Assert.ThrowsAsync<ArgumentNullException>(() => TestSubject.GetSSOToken("space-id", "sso-password", null));
+			Assert.ThrowsAsync<ArgumentNullException>(() => TestSubject.GetSSOToken(null, "space-id", "sso-password", "username"));
+			Assert.ThrowsAsync<ArgumentNullException>(() => TestSubject.GetSSOToken(new Uri("http://birst"), null, "sso-password", "username"));
+			Assert.ThrowsAsync<ArgumentNullException>(() => TestSubject.GetSSOToken(new Uri("http://birst"), "space-id", null, "username"));
+			Assert.ThrowsAsync<ArgumentNullException>(() => TestSubject.GetSSOToken(new Uri("http://birst"), "space-id", "sso-password", null));
 		}
 
 		private void SetupSettings()

--- a/Edge10.Birst/BirstAdminService.cs
+++ b/Edge10.Birst/BirstAdminService.cs
@@ -32,7 +32,7 @@ namespace Edge10.Birst
 		{
 			if (birstConfiguration == null) throw new ArgumentNullException(nameof(birstConfiguration));
 			if (birstServiceWrapper == null) throw new ArgumentNullException(nameof(birstServiceWrapper));
-			if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));			
+			if (httpClient == null) throw new ArgumentNullException(nameof(httpClient));
 
 			_birstConfiguration  = birstConfiguration;
 			_birstServiceWrapper = birstServiceWrapper;
@@ -142,15 +142,16 @@ namespace Edge10.Birst
 		/// <returns></returns>
 		public Task<string> GetSSOToken()
 		{
-			return GetSSOToken(_birstConfiguration.SpaceId, _birstConfiguration.SSOPassword, _birstConfiguration.Email);
+			return GetSSOToken(_birstConfiguration.Uri, _birstConfiguration.SpaceId, _birstConfiguration.SSOPassword, _birstConfiguration.Email);
 		}
 
 		/// <summary>
 		/// Gets the SSO token using provided credentials.
 		/// </summary>
 		/// <returns></returns>
-		public async Task<string> GetSSOToken(string spaceId, string ssoPassword, string username)
+		public async Task<string> GetSSOToken(Uri uri, string spaceId, string ssoPassword, string username)
 		{
+			if (uri         == null) throw new ArgumentNullException(nameof(uri));
 			if (spaceId     == null) throw new ArgumentNullException(nameof(spaceId));
 			if (ssoPassword == null) throw new ArgumentNullException(nameof(ssoPassword));
 			if (username    == null) throw new ArgumentNullException(nameof(username));
@@ -165,7 +166,7 @@ namespace Edge10.Birst
 			using (new SecurityProtocolContext())
 			{
 				var response =
-					await _httpClient.PostAsync(new Uri(_birstConfiguration.Uri, "tokengenerator.aspx"), tokenGeneratorContent);
+					await _httpClient.PostAsync(new Uri(uri, "tokengenerator.aspx"), tokenGeneratorContent);
 
 				if (!response.IsSuccessStatusCode)
 					return null;

--- a/Edge10.Birst/IBirstAdminService.cs
+++ b/Edge10.Birst/IBirstAdminService.cs
@@ -1,4 +1,5 @@
 ﻿using Edge10.Birst.BirstWebService;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -66,6 +67,6 @@ namespace Edge10.Birst
 		/// Gets the SSO token using provided credentials.
 		/// </summary>
 		/// <returns></returns>
-		Task<string> GetSSOToken(string spaceId, string ssoPassword, string username);
+		Task<string> GetSSOToken(Uri uri, string spaceId, string ssoPassword, string username);
 	}
 }


### PR DESCRIPTION
We already have an overload of `GetSSOToken` that takes in the spaceid, password and username for testing details that have not yet been saved.  Because we can now edit the uri too, I'm making this another parameter.