### PR TITLE
Zendesk 20490 fix apac embed

### DIFF
--- a/Edge10.Birst.Tests/TestBirstServiceWrapper.cs
+++ b/Edge10.Birst.Tests/TestBirstServiceWrapper.cs
@@ -48,7 +48,7 @@ namespace Edge10.Birst.Tests
 			//public can run this without making a call to the live service
 			var service = new MsTest.PrivateObject(new BirstServiceWrapper(_configuration.Object)).GetField("_service") as CommandWebService;
 
-			Assert.That(service.Url, Is.EqualTo("http://birst/CommandWebservice.asmx"));
+			Assert.That(service.Url, Is.EqualTo("http://birst/CommandWebService.asmx"));
 			Assert.That(service.CookieContainer, Is.Not.Null);
 		}
 
@@ -59,7 +59,7 @@ namespace Edge10.Birst.Tests
 			//public can run this without making a call to the live service
 			var service = new MsTest.PrivateObject(new BirstServiceWrapper(new Uri("http://birst"))).GetField("_service") as CommandWebService;
 
-			Assert.That(service.Url, Is.EqualTo("http://birst/CommandWebservice.asmx"));
+			Assert.That(service.Url, Is.EqualTo("http://birst/CommandWebService.asmx"));
 			Assert.That(service.CookieContainer, Is.Not.Null);
 		}
 	}

--- a/Edge10.Birst/BirstServiceWrapper.cs
+++ b/Edge10.Birst/BirstServiceWrapper.cs
@@ -45,7 +45,7 @@ namespace Edge10.Birst
 		{
 			_service = new CommandWebService
 			{
-				Url             = new Uri(uri, "CommandWebservice.asmx").ToString(),
+				Url             = new Uri(uri, "CommandWebService.asmx").ToString(),
 				CookieContainer = new CookieContainer()
 			};
 		}

--- a/Edge10.Birst/app.config
+++ b/Edge10.Birst/app.config
@@ -8,7 +8,7 @@
     <applicationSettings>
         <Edge10.Birst.Properties.Settings>
             <setting name="Edge10_Birst_BirstWebService_CommandWebService" serializeAs="String">
-                <value>http://sde.birst.com/CommandWebservice.asmx</value>
+                <value>http://sde.birst.com/CommandWebService.asmx</value>
             </setting>
         </Edge10.Birst.Properties.Settings>
     </applicationSettings>


### PR DESCRIPTION
## Work Item
* Zendesk Ticket 20490

## Description
* Birst supported `CommonWebservice` as a valid URL alongside `CommonWebService`, but since changing to Birst 7, they no longer support `CommonWebservice`